### PR TITLE
Add session revival breadcrumb mechanism

### DIFF
--- a/plugins/walnut/rules/behaviours.md
+++ b/plugins/walnut/rules/behaviours.md
@@ -75,6 +75,21 @@ If the conductor seems lost — about the system, the terminal, or technology �
 
 One clear explanation. Then move on. Don't over-explain. Don't patronise. Don't make it a teaching moment unless they want one.
 
+## 7. Revival Awareness
+
+When reading now.md — at open, at save, at any point in the session — check for a `## Revival` section. If present, surface it:
+
+```
+╭─ 🐿️ revival marker
+│  Previous session flagged for revival: [summary]
+│  → walnut:revive [session_id]
+╰─
+```
+
+This is not a blocking question. It's a hint. The conductor can run `walnut:revive` or ignore it.
+
+The open skill gives revival markers full prominence. Outside of open, the behaviour rule ensures the marker is never silently ignored — even if the conductor jumps straight into work without opening.
+
 ---
 
 ## Mid-Session Write Policy

--- a/plugins/walnut/rules/conventions.md
+++ b/plugins/walnut/rules/conventions.md
@@ -285,3 +285,30 @@ When a new walnut needs to be created (from save routing, capture, or explicit r
 8. If it's a sub-walnut, set `parent: [[parent-name]]` in key.md frontmatter
 9. Add `[[new-walnut-name]]` to parent's key.md `links:` field
 
+---
+
+## Revival Markers
+
+`now.md` may contain an optional `## Revival` section after `## Context`. This is a one-shot marker written by the save skill when the squirrel judges a session had significant conversational context worth recovering.
+
+**Format:**
+```
+session: [session_id]
+date: [YYYY-MM-DD]
+summary: [one sentence]
+```
+
+**Lifecycle:**
+1. Written at save (step 9) when the squirrel judges the session revival-worthy and the conductor confirms
+2. Surfaced at open and whenever now.md is read (behaviour rule)
+3. Cleared on next save regardless of whether revival was run
+4. Only one marker at a time — if save writes a new one, it replaces the old one
+
+**What makes a session revival-worthy:**
+- Extended back-and-forth discussion with nuanced decisions
+- Design exploration or brainstorming with reasoning not fully captured in files
+- Complex debugging or problem-solving with context that matters for continuation
+- The conductor explicitly mentioned wanting to continue this thread
+
+Quick tasks, simple updates, and sessions where the log entry captures everything are NOT revival-worthy. The squirrel should not offer revival on every save — only when conversational context would genuinely be lost.
+

--- a/plugins/walnut/rules/world.md
+++ b/plugins/walnut/rules/world.md
@@ -103,6 +103,24 @@ squirrel: 2a8c95e9
 
 **next: protection:** At save, the squirrel checks whether the previous `next:` was completed. If not, it surfaces the conflict. The previous `next:` is never silently dropped.
 
+### now.md Revival Section
+
+An optional `## Revival` section may appear in now.md after `## Context`. This is a lightweight breadcrumb written by the save skill when the squirrel judges a session had significant conversational context worth recovering via `walnut:revive`.
+
+```
+## Revival
+
+session: 2a8c95e9
+date: 2026-03-02
+summary: Deep design discussion on shielding vendor trade-offs — narrowed to three options, no final pick.
+```
+
+**Rules:**
+- Present = revival pending. Absent = nothing to revive.
+- Only one revival marker at a time (latest save wins).
+- Cleared on next save regardless of whether revival was run. One-shot marker.
+- The squirrel surfaces this whenever now.md is read (behaviour rule). The open skill surfaces it prominently.
+
 ### log.md Frontmatter
 
 ```yaml

--- a/plugins/walnut/skills/open/SKILL.md
+++ b/plugins/walnut/skills/open/SKILL.md
@@ -75,6 +75,21 @@ Read in order (show `▸` reads):
 ▸ _references/ 8 companions (3 transcripts, 3 emails, 2 research)
 ```
 
+## Revival Check
+
+After loading now.md, check whether it contains a `## Revival` section. If present, surface it prominently before the Spark:
+
+```
+╭─ 🐿️ previous session flagged for revival
+│  [date]: [summary from the revival section]
+│  Run walnut:revive [session_id] to restore that context.
+╰─
+```
+
+This is a recommendation, not a blocking question. The conductor can run `walnut:revive` immediately, or proceed with the normal open flow and revive later (or never).
+
+If the conductor runs `walnut:revive`, the revival section will be cleared on the next save.
+
 ## The Spark
 
 One observation the conductor might not have seen. A connection, a question, a nudge.

--- a/plugins/walnut/skills/save/SKILL.md
+++ b/plugins/walnut/skills/save/SKILL.md
@@ -159,7 +159,44 @@ Not a vibe check. A concrete checklist. Run through each:
 
 If anything fails, fix it before completing the save. This is the last gate.
 
-### 9. Continue
+### 9. Revival Judgment
+
+After the integrity check, evaluate whether this session had substantive conversational context beyond what the log entry and now.md capture.
+
+**Indicators of a revival-worthy session:**
+- Extended back-and-forth discussion with nuanced decisions
+- Design exploration or brainstorming with reasoning not fully in the files
+- Complex debugging or problem-solving with context that matters for continuation
+- The conductor explicitly mentioned wanting to continue this thread
+
+**NOT revival-worthy:** Quick tasks, simple updates, sessions where the log entry captures everything. Don't offer revival on every save.
+
+If the squirrel judges the session revival-worthy:
+
+```
+╭─ 🐿️ revival
+│  This session had [brief reason — e.g. "deep design discussion",
+│  "complex debugging with multiple approaches explored"].
+│  Need the full conversation context back when you return?
+│  → yes / no
+╰─
+```
+
+If yes: write a `## Revival` section to now.md (which was already updated in step 7):
+
+```markdown
+## Revival
+
+session: [this session's session_id]
+date: [today's date]
+summary: [one sentence the squirrel drafts — no extra question needed]
+```
+
+If the conductor previously had a revival marker that was never used, it gets replaced. One marker at a time.
+
+If no, or if the session wasn't revival-worthy: skip. No section written.
+
+### 10. Continue
 
 Session continues. Stash resets for next checkpoint.
 

--- a/plugins/walnut/templates/walnut/now.md
+++ b/plugins/walnut/templates/walnut/now.md
@@ -31,3 +31,15 @@ squirrel: {{session_id}}
      Meridian partnership paused until after test window. Next milestone
      is the crewed test itself.
 -->
+
+## Revival
+
+<!-- OPTIONAL. Written by save skill when a session had significant
+     conversational context worth recovering via walnut:revive.
+
+     session: [session_id]
+     date: [YYYY-MM-DD]
+     summary: [one sentence]
+
+     Present = revival pending. Absent = nothing to revive.
+     Only one marker at a time. Cleared on next save. -->


### PR DESCRIPTION
## Summary

- Save skill gains step 9 (Revival Judgment) — squirrel evaluates whether a session had significant conversational context worth recovering, asks the conductor, and optionally writes a lightweight `## Revival` section to now.md
- Open skill detects the Revival section and recommends running `walnut:revive` before the Spark
- New behaviour #7 (Revival Awareness) ensures the marker is surfaced whenever now.md is read — not just at open
- Template, world.md, and conventions.md document the format and lifecycle

Replaces the old handoff approach that scraped full conversations at save time. This writes ~5 lines to now.md instead — the heavy lifting stays in `walnut:revive` running in a fresh context window.

## Files changed (6)

| File | Change |
|------|--------|
| `templates/walnut/now.md` | `## Revival` section with format comment |
| `rules/world.md` | `### now.md Revival Section` spec |
| `rules/conventions.md` | `## Revival Markers` — format, lifecycle, criteria |
| `rules/behaviours.md` | `## 7. Revival Awareness` — surface on any now.md read |
| `skills/save/SKILL.md` | Step 9: Revival Judgment (steps renumbered 1→10) |
| `skills/open/SKILL.md` | `## Revival Check` between Load Sequence and Spark |

## Test plan

- [ ] Open a walnut, run a substantive session, save — verify the squirrel offers revival judgment
- [ ] Confirm revival marker appears in now.md after saying "yes"
- [ ] Open the walnut in a new session — verify the revival marker is surfaced
- [ ] Run walnut:revive with the session_id — verify context recovery works
- [ ] Save again — verify the revival marker is cleared
- [ ] Run a simple/short session and save — verify the squirrel does NOT offer revival

🤖 Generated with [Claude Code](https://claude.com/claude-code)