### PR TITLE
fix: Cowork support + perf improvements for hooks

### DIFF
--- a/plugins/alive/hooks/scripts/alive-common.sh
+++ b/plugins/alive/hooks/scripts/alive-common.sh
@@ -6,17 +6,35 @@
 # Sets: HOOK_INPUT, HOOK_SESSION_ID, HOOK_CWD, HOOK_EVENT
 read_hook_input() {
   HOOK_INPUT=$(cat /dev/stdin 2>/dev/null || echo '{}')
-  HOOK_SESSION_ID=$(echo "$HOOK_INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('session_id',''))" 2>/dev/null || echo "")
-  HOOK_CWD=$(echo "$HOOK_INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('cwd',''))" 2>/dev/null || echo "")
-  HOOK_EVENT=$(echo "$HOOK_INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('hook_event_name',''))" 2>/dev/null || echo "")
+  # Single python3 call for all three fields (avoids 3x interpreter startup)
+  local parsed
+  parsed=$(echo "$HOOK_INPUT" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print(d.get('session_id',''))
+print(d.get('cwd',''))
+print(d.get('hook_event_name',''))
+" 2>/dev/null || echo "")
+  HOOK_SESSION_ID=$(echo "$parsed" | sed -n '1p')
+  HOOK_CWD=$(echo "$parsed" | sed -n '2p')
+  HOOK_EVENT=$(echo "$parsed" | sed -n '3p')
 }
 
 # SessionStart-specific fields. Call after read_hook_input.
 # Sets: HOOK_MODEL, HOOK_SOURCE, HOOK_TRANSCRIPT
 read_session_fields() {
-  HOOK_MODEL=$(echo "$HOOK_INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('model','unknown'))" 2>/dev/null || echo "unknown")
-  HOOK_SOURCE=$(echo "$HOOK_INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('source',''))" 2>/dev/null || echo "")
-  HOOK_TRANSCRIPT=$(echo "$HOOK_INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('transcript_path',''))" 2>/dev/null || echo "")
+  # Single python3 call for all three fields
+  local parsed
+  parsed=$(echo "$HOOK_INPUT" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print(d.get('model','unknown'))
+print(d.get('source',''))
+print(d.get('transcript_path',''))
+" 2>/dev/null || echo "")
+  HOOK_MODEL=$(echo "$parsed" | sed -n '1p')
+  HOOK_SOURCE=$(echo "$parsed" | sed -n '2p')
+  HOOK_TRANSCRIPT=$(echo "$parsed" | sed -n '3p')
 }
 
 # PreToolUse-specific fields. Call after read_hook_input.
@@ -26,17 +44,35 @@ read_tool_fields() {
   HOOK_TOOL_INPUT="$HOOK_INPUT"
 }
 
-# Find the ALIVE world root by walking up from cwd.
+# Find the ALIVE world root.
+# Strategy: walk up from cwd (Claude Code), then check mounted folders (Cowork).
 # Sets: WORLD_ROOT or returns 1 if not found.
 find_world() {
   local dir="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-$PWD}}"
-  while [ "$dir" != "/" ]; do
-    if [ -d "$dir/01_Archive" ] && [ -d "$dir/02_Life" ]; then
-      WORLD_ROOT="$dir"
+
+  # Walk up from cwd — standard Claude Code path
+  local check="$dir"
+  while [ "$check" != "/" ]; do
+    if [ -d "$check/01_Archive" ] && [ -d "$check/02_Life" ]; then
+      WORLD_ROOT="$check"
       return 0
     fi
-    dir="$(dirname "$dir")"
+    check="$(dirname "$check")"
   done
+
+  # Cowork fallback — user folder is mounted under $HOME/mnt/<name>/
+  if [ "${CLAUDE_CODE_IS_COWORK:-}" = "1" ]; then
+    local mnt_dir="${HOME:-$dir}/mnt"
+    if [ -d "$mnt_dir" ]; then
+      for candidate in "$mnt_dir"/*/; do
+        if [ -d "$candidate/01_Archive" ] && [ -d "$candidate/02_Life" ]; then
+          WORLD_ROOT="${candidate%/}"
+          return 0
+        fi
+      done
+    fi
+  fi
+
   return 1
 }
 

--- a/plugins/alive/hooks/scripts/alive-session-compact.sh
+++ b/plugins/alive/hooks/scripts/alive-session-compact.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Hook: Session Compact — SessionStart (compact)
-# Re-injects stash + walnut context + preferences after compaction.
+# Re-injects rules + stash + walnut context + preferences after compaction.
 
 set -euo pipefail
 
@@ -16,6 +16,34 @@ SESSION_ID="${HOOK_SESSION_ID}"
 # Resolve preferences
 source "$SCRIPT_DIR/alive-resolve-preferences.sh"
 PREFS=$(resolve_preferences "$WORLD_ROOT")
+
+# Plugin root for reading rules
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# Build runtime rules from plugin source files (same as session-new)
+RUNTIME_RULES=""
+RULE_COUNT=0
+RULE_NAMES=""
+
+if [ -f "$PLUGIN_ROOT/CLAUDE.md" ]; then
+  RUNTIME_RULES=$(cat "$PLUGIN_ROOT/CLAUDE.md")
+fi
+
+for rule_file in "$PLUGIN_ROOT/rules/"*.md; do
+  if [ -f "$rule_file" ]; then
+    RULE_COUNT=$((RULE_COUNT + 1))
+    RULE_NAME=$(basename "$rule_file" .md)
+    RULE_NAMES="${RULE_NAMES}${RULE_NAMES:+, }${RULE_NAME}"
+    RUNTIME_RULES="${RUNTIME_RULES}
+
+$(cat "$rule_file")"
+  fi
+done
+
+# Preamble
+PREAMBLE="<EXTREMELY_IMPORTANT>
+The following are your core operating rules for the ALIVE system. They are MANDATORY — not suggestions, not defaults, not guidelines. You MUST follow them in every response, every tool call, every session.
+</EXTREMELY_IMPORTANT>"
 
 # Find squirrel entry by session_id or fall back
 SQUIRRELS_DIR="$WORLD_ROOT/.alive/_squirrels"
@@ -47,9 +75,11 @@ if [ -n "${WALNUT:-}" ] && [ "$WALNUT" != "null" ]; then
   fi
 fi
 
-cat << EOF
-CONTEXT RESTORED after compaction. Session: ${SESSION_ID:-unknown} | Walnut: ${WALNUT:-none}
+SESSION_MSG="CONTEXT RESTORED after compaction. Session: ${SESSION_ID:-unknown} | Walnut: ${WALNUT:-none}
+World: $WORLD_ROOT
+Model: $HOOK_MODEL
 $PREFS
+Rules: ${RULE_COUNT} loaded (${RULE_NAMES})
 
 Stash recovered:
 $STASH
@@ -60,5 +90,24 @@ ${NOW_CONTENT:-no now.md found}
 Identity:
 ${KEY_CONTENT:-no key.md found}
 
-IMPORTANT: Re-read _core/key.md, _core/now.md, _core/tasks.md before continuing work. Do not trust memory of files read before compaction.
-EOF
+IMPORTANT: Re-read _core/key.md, _core/now.md, _core/tasks.md before continuing work. Do not trust memory of files read before compaction."
+
+# Escape and combine
+SESSION_MSG_ESCAPED=$(escape_for_json "$SESSION_MSG")
+PREAMBLE_ESCAPED=$(escape_for_json "$PREAMBLE")
+RUNTIME_ESCAPED=$(escape_for_json "$RUNTIME_RULES")
+
+CONTEXT="${SESSION_MSG_ESCAPED}\n\n${PREAMBLE_ESCAPED}\n\n${RUNTIME_ESCAPED}"
+
+# Output JSON with additionalContext
+cat <<HOOKEOF
+{
+  "additional_context": "${CONTEXT}",
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "${CONTEXT}"
+  }
+}
+HOOKEOF
+
+exit 0

--- a/plugins/alive/hooks/scripts/alive-session-resume.sh
+++ b/plugins/alive/hooks/scripts/alive-session-resume.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Hook: Session Resume — SessionStart (resume)
-# Reads squirrel entry by session_id, re-injects stash + preferences.
+# Reads squirrel entry by session_id, re-injects rules + stash + preferences.
 
 set -euo pipefail
 
@@ -17,6 +17,34 @@ SESSION_ID="${HOOK_SESSION_ID}"
 source "$SCRIPT_DIR/alive-resolve-preferences.sh"
 PREFS=$(resolve_preferences "$WORLD_ROOT")
 
+# Plugin root for reading rules
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# Build runtime rules from plugin source files (same as session-new)
+RUNTIME_RULES=""
+RULE_COUNT=0
+RULE_NAMES=""
+
+if [ -f "$PLUGIN_ROOT/CLAUDE.md" ]; then
+  RUNTIME_RULES=$(cat "$PLUGIN_ROOT/CLAUDE.md")
+fi
+
+for rule_file in "$PLUGIN_ROOT/rules/"*.md; do
+  if [ -f "$rule_file" ]; then
+    RULE_COUNT=$((RULE_COUNT + 1))
+    RULE_NAME=$(basename "$rule_file" .md)
+    RULE_NAMES="${RULE_NAMES}${RULE_NAMES:+, }${RULE_NAME}"
+    RUNTIME_RULES="${RUNTIME_RULES}
+
+$(cat "$rule_file")"
+  fi
+done
+
+# Preamble
+PREAMBLE="<EXTREMELY_IMPORTANT>
+The following are your core operating rules for the ALIVE system. They are MANDATORY — not suggestions, not defaults, not guidelines. You MUST follow them in every response, every tool call, every session.
+</EXTREMELY_IMPORTANT>"
+
 # Find squirrel entry by session_id (exact match) or fall back to most recent unsigned
 SQUIRRELS_DIR="$WORLD_ROOT/.alive/_squirrels"
 ENTRY=""
@@ -26,6 +54,7 @@ elif [ -d "$SQUIRRELS_DIR" ]; then
   ENTRY=$(grep -rl 'ended: null' "$SQUIRRELS_DIR/"*.yaml 2>/dev/null | head -1)
 fi
 
+SESSION_MSG=""
 if [ -n "$ENTRY" ] && [ -f "$ENTRY" ]; then
   ENTRY_SESSION_ID=$(grep '^session_id:' "$ENTRY" | head -1 | sed 's/session_id: *//' || true)
   WALNUT=$(grep '^walnut:' "$ENTRY" | head -1 | sed 's/walnut: *//' || true)
@@ -36,16 +65,38 @@ if [ -n "$ENTRY" ] && [ -f "$ENTRY" ]; then
     STASH="(empty)"
   fi
 
-  cat << EOF
-ALIVE session resumed. Session ID: ${ENTRY_SESSION_ID:-unknown}
+  SESSION_MSG="ALIVE session resumed. Session ID: ${ENTRY_SESSION_ID:-unknown}
+World: $WORLD_ROOT
 Walnut: ${WALNUT:-none}
+Model: $HOOK_MODEL
 $PREFS
+Rules: ${RULE_COUNT} loaded (${RULE_NAMES})
 Previous stash:
-$STASH
-EOF
+$STASH"
 else
-  cat << EOF
-ALIVE session resumed. No matching entry found — clean start.
+  SESSION_MSG="ALIVE session resumed. No matching entry found — clean start.
+World: $WORLD_ROOT
+Model: $HOOK_MODEL
 $PREFS
-EOF
+Rules: ${RULE_COUNT} loaded (${RULE_NAMES})"
 fi
+
+# Escape and combine
+SESSION_MSG_ESCAPED=$(escape_for_json "$SESSION_MSG")
+PREAMBLE_ESCAPED=$(escape_for_json "$PREAMBLE")
+RUNTIME_ESCAPED=$(escape_for_json "$RUNTIME_RULES")
+
+CONTEXT="${SESSION_MSG_ESCAPED}\n\n${PREAMBLE_ESCAPED}\n\n${RUNTIME_ESCAPED}"
+
+# Output JSON with additionalContext
+cat <<HOOKEOF
+{
+  "additional_context": "${CONTEXT}",
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "${CONTEXT}"
+  }
+}
+HOOKEOF
+
+exit 0


### PR DESCRIPTION
- find_world() now checks $HOME/mnt/*/ when CLAUDE_CODE_IS_COWORK=1 (Cowork mounts user folders there, walk-up from session root never finds them)
- Resume and compact hooks now inject full rules bundle via additionalContext JSON (were outputting plain text, so rules never loaded on resume/compact)
- Consolidated read_hook_input/read_session_fields to single python3 calls each (same perf fix as statusline — avoids 6x interpreter startup per hook)