### PR TITLE
fix: BLOCKING — marketplace.json schema prevents plugin installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,9 @@
 {
   "name": "walnut",
-  "owner": "stackwalnuts",
+  "owner": {
+    "name": "Stack Walnuts",
+    "email": "hello@walnut.world"
+  },
   "metadata": {
     "description": "Your life in walnuts. A personal context system — structured units of knowledge and work on your machine, connected to everything. Gather from any source. Curate with any AI. Prototype and ship through capsules. Share on walnut.world. Earn from what you build.",
     "version": "1.0.0"


### PR DESCRIPTION
## URGENT — blocks all new installations

`owner` in `.claude-plugin/marketplace.json` is a plain string (`"stackwalnuts"`) but Claude Code's marketplace schema requires it to be an object with `name` and `email` fields. This means **nobody can add the walnut marketplace** until this is merged.

### Error users see

```
Failed to parse marketplace file: Invalid schema:
  owner: Invalid input: expected object, received string
```

### Fix

One-line change — `"owner": "stackwalnuts"` → `"owner": { "name": "Stack Walnuts", "email": "hello@walnut.world" }`

Matched the format used by `claude-plugins-official` and `cc-marketplace`.

### Test

After merging, run:
```
/install-plugin stackwalnuts/walnut
```
Should succeed without schema errors.