### PR TITLE
feat: add alive:end-session skill for explicit session closing

### DIFF
--- a/plugins/alive/CLAUDE.md
+++ b/plugins/alive/CLAUDE.md
@@ -46,12 +46,13 @@ Do not respond about a walnut without reading its kernel files. Never guess at f
 
 ---
 
-## Fifteen Skills
+## Sixteen Skills
 
 ```
 /alive:world                  see your world
 /alive:load-context           load a walnut (prev. open)
 /alive:save                   checkpoint — route stash, update state
+/alive:end-session            close session — route stash, stamp exit
 /alive:capture-context        context in — store, route
 /alive:bundle                 create, share, graduate bundles
 /alive:search-world           search across walnuts

--- a/plugins/alive/skills/end-session/SKILL.md
+++ b/plugins/alive/skills/end-session/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: alive:end-session
+description: "Explicitly close the current session. Routes any unsaved stash, sets ended: timestamp, writes a closing log entry. Use when the human says they're done — 'done', 'wrapping up', 'that's it for now', 'end session'. Prevents ghost squirrels that accumulate with ended: null."
+user-invocable: true
+---
+
+# End
+
+Close this session cleanly. Route unsaved stash, stamp the exit, move on.
+
+Not a save (that's `alive:save` — checkpoints mid-session, keeps the session open). End is final. The squirrel closes its entry, signs off, and the session is done.
+
+---
+
+## Why This Exists
+
+Sessions that end by closing the terminal, disconnecting, or just walking away never get their squirrel entry closed. The `ended:` field stays `null` forever. Over time these ghost squirrels accumulate — polluting session history, confusing cleanup, and making the fallback patterns in hooks pick up wrong sessions.
+
+This skill gives the human a clean exit. One command, session closed properly.
+
+---
+
+## Flow
+
+### Step 1 — Check Session State
+
+Read the current squirrel entry at `.alive/_squirrels/{session_id}.yaml`.
+
+If no entry exists, there's nothing to close:
+
+```
+╭─ 🐿️ no active session to close.
+╰─
+```
+
+Exit.
+
+### Step 2 — Check for Unsaved Stash
+
+Read the `stash:` field from the squirrel YAML. Also check the in-conversation stash — items may have been collected but not yet written to the YAML.
+
+**If stash has unrouted items (saves: 0 or new items since last save):**
+
+```
+╭─ 🐿️ you have unsaved stash items
+│
+│  Decisions:
+│  - [decision items]
+│
+│  Tasks:
+│  - [task items]
+│
+│  Notes:
+│  - [note items]
+│
+│  ▸ save and close / drop and close / cancel
+╰─
+```
+
+- **save and close** — invoke the `alive:save` flow first (route stash, write log, update projections), then continue to Step 3
+- **drop and close** — skip stash routing, continue to Step 3. The stash stays in the YAML as a historical record but is not routed to walnut files.
+- **cancel** — abort. Session stays open.
+
+**If no unsaved stash (empty stash or saves > 0 with no new items):**
+
+Skip straight to Step 3.
+
+### Step 3 — Write Closing Log Entry
+
+If a walnut is active (`walnut:` field is not null), prepend a closing entry to `_kernel/log.md`:
+
+```markdown
+## {timestamp} — squirrel:{session_id}
+
+Session closed.
+
+signed: squirrel:{session_id}
+```
+
+If the session had meaningful work (saves > 0), the log entry should be minimal — the save entries already captured the substance. Don't repeat what's already logged.
+
+If no walnut is active, skip the log entry.
+
+### Step 4 — Close the Squirrel Entry
+
+Update `.alive/_squirrels/{session_id}.yaml`:
+
+- Set `ended:` to current ISO timestamp
+- Set `transcript:` if not already set — check for JSONL at `~/.claude/projects/*/` matching the session ID
+
+### Step 5 — Confirm
+
+```
+╭─ 🐿️ session closed
+│
+│  squirrel:{short_id} — {walnut or "no walnut"} — {saves} saves
+│  ended: {timestamp}
+╰─
+```
+
+---
+
+## Edge Cases
+
+| Situation | Behavior |
+|-----------|----------|
+| No squirrel entry exists | Print "no active session" and exit |
+| Squirrel already has `ended:` set | Print "session already closed" and exit |
+| Walnut is null (never loaded) | Close squirrel without log entry |
+| Save flow fails mid-close | Still set `ended:` — partial close is better than ghost |
+| Human says "cancel" at stash prompt | Abort entirely, session stays open |
+
+---
+
+## Files Read
+
+| File | Why |
+|------|-----|
+| `.alive/_squirrels/{session_id}.yaml` | Current session state |
+| `_kernel/log.md` | Prepend closing entry (if walnut active) |
+
+## Files Written
+
+| File | What |
+|------|------|
+| `.alive/_squirrels/{session_id}.yaml` | Set `ended:`, update `transcript:` |
+| `_kernel/log.md` | Closing log entry (if walnut active) |

--- a/plugins/alive/skills/save/SKILL.md
+++ b/plugins/alive/skills/save/SKILL.md
@@ -198,13 +198,9 @@ The check suggestion is lightweight — one line. If the human ignores it, no fr
 
 ## On Actual Session Exit
 
-When the session truly ends (stop hook, explicit "I'm done done", the human leaves):
+When the session truly ends (explicit "I'm done", "wrapping up", "end session"):
 
-- Update the squirrel entry in `.alive/_squirrels/{session_id}.yaml`:
-  - Set `ended:` to current timestamp
-  - `saves:` is already > 0 from the last save
-  - Set `transcript_path:` — scan `~/.claude/projects/*/` for a JSONL file containing the session ID
-- The entry is already saved — this step adds the exit metadata
+Invoke `alive:end-session`. It handles stash routing, closing log entry, and setting `ended:` on the squirrel. Save is a checkpoint — end-session is the exit.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `/alive:end-session` — an explicit command to cleanly close a session
- Routes unsaved stash, writes closing log entry, sets `ended:` timestamp on squirrel YAML
- Updates save skill to delegate session exit to end-session instead of inlining the protocol
- Registers as the 16th skill in CLAUDE.md

## Problem

Sessions that end by closing the terminal, disconnecting, or just walking away never get their squirrel entry closed. The `ended:` field stays `null` forever. Over time these ghost squirrels accumulate — polluting session history, confusing `system-cleanup`, and causing fallback patterns in hooks (`grep -rl 'ended: null'`) to pick up wrong sessions.

A `SessionEnd` hook was considered but rejected: it would break session resume, since the resume hook looks for `ended: null` to find active sessions. An explicit skill is the right design — the human decides when they're truly done.

## Changes

| File | Change |
|------|--------|
| `plugins/alive/skills/end-session/SKILL.md` | New skill — full flow with stash check, closing log, squirrel update |
| `plugins/alive/CLAUDE.md` | Register as 16th skill |
| `plugins/alive/skills/save/SKILL.md` | "On Actual Session Exit" now delegates to end-session |

## Test plan

- [ ] Start a session, stash some items, run `/alive:end-session` — verify stash routing prompt appears
- [ ] Run `/alive:end-session` with no stash — verify it skips straight to closing
- [ ] Check squirrel YAML after close — `ended:` should have ISO timestamp
- [ ] Run `/alive:end-session` on an already-closed session — should print "session already closed"
- [ ] Resume a session that was NOT end-sessioned — verify resume still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)