### PR TITLE
Bugfix warmup — world skill inbox, load-context session claim, index regen triggers

### DIFF
--- a/plugins/alive/hooks/scripts/alive-post-write.sh
+++ b/plugins/alive/hooks/scripts/alive-post-write.sh
@@ -62,10 +62,14 @@ case "$FILE_PATH" in
     ;;
 esac
 
-# Regenerate world index after save
-# now.json is only written by save (per rules) -- use it as the trigger
+# Regenerate world index after save OR after a write that lands in 03_Inbox/.
+# now.json is the canonical save trigger; 03_Inbox writes are added so
+# agent-driven captures don't leave the index stale until the next save.
+# Files dragged into 03_Inbox/ outside of Claude Code (Finder, scripts) still
+# rely on the session-start refresh in alive-session-new.sh -- there's no tool
+# event for those.
 case "$FILE_PATH" in
-  */_kernel/now.json|*/_kernel/_generated/now.json|*/_kernel/now.md)
+  */_kernel/now.json|*/_kernel/_generated/now.json|*/_kernel/now.md|*/03_Inbox/*)
     GENERATOR="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}/scripts/generate-index.py"
     if [ -f "$GENERATOR" ]; then
       # Debounce -- skip if we regenerated in the last 5 minutes

--- a/plugins/alive/hooks/scripts/alive-session-new.sh
+++ b/plugins/alive/hooks/scripts/alive-session-new.sh
@@ -250,6 +250,21 @@ if [ -f "$WORLD_KEY_FILE" ]; then
   WORLD_KEY_CONTENT=$(cat "$WORLD_KEY_FILE")
 fi
 
+# Refresh the world index before reading it so the injection is current.
+# generate-index.py is otherwise only triggered by post-write hooks on save
+# events (or now on writes to 03_Inbox/), which means anything that mutated
+# state between sessions -- files dropped into 03_Inbox/ via Finder, parallel
+# session saves, manual edits -- would leave _index.yaml stale until the next
+# in-session save chain. Run it synchronously here (measured ~110ms on a
+# 16-walnut world) so this session sees the truth from byte one. Touch the
+# debounce marker so subsequent post-write triggers within the next 5 minutes
+# skip the redundant work.
+GENERATOR="$PLUGIN_ROOT/scripts/generate-index.py"
+if [ -f "$GENERATOR" ] && [ "$ALIVE_JSON_RT" = "python3" ]; then
+  python3 "$GENERATOR" "$WORLD_ROOT" > /dev/null 2>&1 || true
+  touch "/tmp/alive-index-regen" 2>/dev/null || true
+fi
+
 # Read world index (.alive/_index.yaml) for injection -- walnut registry
 WORLD_INDEX_CONTENT=""
 WORLD_INDEX_FILE="$WORLD_ROOT/.alive/_index.yaml"

--- a/plugins/alive/skills/load-context/SKILL.md
+++ b/plugins/alive/skills/load-context/SKILL.md
@@ -37,19 +37,20 @@ Show available walnuts as a numbered list grouped by domain:
 
 ---
 
-## Tier 1 — Brief Pack (3 files)
+## Tier 1 — Brief Pack (3 files) + claim the session
 
 Read these three files. That's it — everything you need to orient.
 
 1. `_kernel/key.md` — full file (identity, people, links, rhythm)
 2. `_kernel/now.json` — full file (phase, next action, bundle statuses with task summaries, recent sessions, nested walnut state, blockers, context paragraph)
 3. `_kernel/insights.md` — frontmatter only (what domain knowledge sections exist)
+4. **Claim this session for the walnut** — Edit `.alive/_squirrels/{your-session-id}.yaml` and change the `walnut:` field from `null` to the walnut's directory basename (e.g. `walnut: berties`, `walnut: alive-os`). Your session ID is in the SessionStart injection at the top of context (`Session ID: ...`); the squirrel YAML lives under the world's `.alive/_squirrels/` directory using the full UUID as the filename. **This step is mandatory, not optional.** Cross-session hooks (`alive-context-watch.sh`, the statusline, `project.py`'s recent-sessions aggregator) all read `walnut:` from this YAML to know which walnut you're on. If you skip this, parallel-session change detection silently no-ops, the statusline shows the wrong context, and projections under-count your activity. Use a single Edit with `old_string: "walnut: null"` and `new_string: "walnut: {name}"`. If the YAML already has a different walnut name (rare — cross-walnut session), leave it and surface the conflict to the human.
 
 **DO NOT read any other files at this stage.** No log.md. No bundle manifests. No tasks files. No squirrel entries. All of that data is already in now.json — the projection script aggregated it. Reading source files at load wastes context window on data you already have.
 
 **Inbox triage (background):** After reading the brief pack, check if `03_Inbox/` has items (`ls 03_Inbox/ 2>/dev/null`). If yes, dispatch a background triage agent (same spec as in the world skill — reads items, tags type/destination/priority, returns structured report). Don't wait for it — continue with people resolution and the Spark. Results arrive while you work.
 
-Show `>` reads as you go:
+Show `>` reads as you go, and surface the claim:
 
 ```
 > _kernel/key.md           Lock-in Lab — launching, weekly rhythm, 3 people
@@ -57,6 +58,7 @@ Show `>` reads as you go:
                             Active bundles: 2 (official-launch: 1 urgent, 18 todo; research: 4 todo)
                             Blockers: none. Recent: 3 sessions.
 > _kernel/insights.md       4 domain knowledge sections
+✓ claimed session for lock-in-lab (squirrel YAML updated)
 ```
 
 **Backward compat fallback chain:**

--- a/plugins/alive/skills/world/SKILL.md
+++ b/plugins/alive/skills/world/SKILL.md
@@ -19,7 +19,11 @@ NOT a database dump. NOT a flat list. A living view of their world, grouped by w
 3. Build the tree from the index — parent/child relationships from `parent:` field
 4. **Lightweight fresh checks** — one Bash call each, no subagents, no Explore agents:
    - **Unsigned squirrels with stash:** already in the index as `unsigned_with_stash:`. If non-zero, surface in the Attention section. No bash loop needed.
-   - **Unrouted inputs:** `ls 03_Inbox/ 2>/dev/null | grep -v '^\.' | grep -v '^Icon'` — just the filenames, no deep reads.
+   - **Unrouted inputs:** resolve the world root first (it's NOT reliably set as a shell var — read it from the install config file), then list the absolute path. Never use a relative `ls 03_Inbox/` — it silently fails when the Bash tool's cwd isn't the world root. One-liner:
+     ```bash
+     WR=$(cat ~/.config/alive/world-root 2>/dev/null | tr -d '[:space:]'); ls "$WR/03_Inbox/" 2>/dev/null | grep -v '^\.' | grep -v '^Icon'
+     ```
+     Just the filenames, no deep reads.
    - **API context:** only if context sources are listed in the session start injection (already in your context from the hook — do NOT re-read preferences.yaml).
 5. Compute attention items from fresh checks + index staleness signals
 6. **Inbox triage (background)** — if `03_Inbox/` has items, dispatch a background agent to triage them. Don't wait for it — render the dashboard immediately, the triage results arrive while the human reads.


### PR DESCRIPTION
## Summary

Three bugs diagnosed during the 2026-04-14 always-alive-loop design session, all sharing a pattern: hooks and skills with the right intent but brittle implementation that silently failed. Shipping as a precursor PR so larger work (always-alive-loop, Cowork restoration) lands on clean foundations.

4 files, +31/-6, 3 commits — one per bug. All three have empirical end-to-end verification against a real ALIVE world. No new runtime dependencies.

---

## t001 — `/alive:world` skill inbox detection (`skills/world/SKILL.md`)

**Diagnosis.** The Load Sequence ran `ls 03_Inbox/ 2>/dev/null | grep -v '^\.' | grep -v '^Icon'` — a relative path. When the Bash tool's cwd isn't exactly the world root the command silently returns empty and the dashboard renders "0 items (clean)" even with real files in the inbox. The hook counterpart `alive-inbox-check.sh` works correctly because it uses `find_world` + absolute path; the skill side didn't have the same discipline.

**Fix.** Replaced with a one-liner that resolves the world root from `~/.config/alive/world-root` (the install-time config file, cross-platform, always present on a configured install — already used by `alive-common.sh`'s `find_world`):

```bash
WR=$(cat ~/.config/alive/world-root 2>/dev/null | tr -d '[:space:]'); ls "$WR/03_Inbox/" 2>/dev/null | grep -v '^\.' | grep -v '^Icon'
```

**Note on `$WORLD_ROOT` shadow bug.** The existing `$WORLD_ROOT` reference elsewhere in the same skill (line 232, the `generate-index.py` invocation) is a pre-existing latent bug — `alive-session-new.sh` writes `ALIVE_WORLD_ROOT` (different name) to `CLAUDE_ENV_FILE`, not `WORLD_ROOT`. The skill's `$WORLD_ROOT` is empty in the Bash tool's shell. Out of scope for this PR but worth flagging.

**Verification (before/after from `/tmp`):**

```
=== BEFORE (old relative path from /tmp) ===
(empty output = bug)

=== AFTER (new absolute path from /tmp) ===
ThoughtFox Dev Onboarding Guide Apr 14 2026.txt
Will x Ben Standup Supernormal Alive Os.md
```

5 dummy test cases all green: real inbox, empty inbox, mixed inbox with `.DS_Store` + `.archive/` subdir correctly filtered, run from unrelated cwd (`~/Library`), regression test of the old broken command.

---

## t002 — `/alive:load-context` doesn't claim the session for its walnut (`skills/load-context/SKILL.md`)

**Diagnosis.** Originally suspected to be a bug in `alive-context-watch.sh` (stale tmp markers, session ID compare, mtime logic). Tracing the hook against a real world showed the hook logic is correct — it was bailing on line 160 (`[ "$WALNUT" = "null" ] && exit 0`) and never reaching the external-change-detection block.

**Root cause.** `alive-session-new.sh` writes the squirrel YAML at session start with `walnut: null`. Nothing updates that field until save time. `load-context/SKILL.md` had **zero** instructions to claim the walnut by writing it into the session's squirrel YAML. So between session start and first save, the YAML's `walnut:` field is null, and any consumer that reads it (the context-watch hook, the statusline, `project.py`'s recent-sessions aggregator) silently no-ops.

Confirmed live: a real session that had been working on a walnut for 90 minutes had `walnut: null`, `saves: 0`, and zero `/tmp/alive-lastcheck-{session-id}` marker file.

**Fix.** Added a new mandatory step 4 to Tier 1 instructing load-context to Edit `.alive/_squirrels/{session_id}.yaml` and replace `walnut: null` with `walnut: {name}`. Single Edit call. Uses the session ID from the SessionStart injection. If the YAML already has a different walnut name (rare — cross-walnut session), the Edit's `old_string: "walnut: null"` won't match and the agent surfaces the conflict instead of silently overwriting.

**End-to-end verification:**

1. Set a real session's squirrel YAML to `walnut: alive-os` (simulating what the new instruction does)
2. Backdated `/tmp/alive-lastcheck-{session-id}` to 1 hour before `alive-os/_kernel/now.json`'s mtime (simulating "another session saved between our last prompt and now")
3. Pre-set the CTX_PCT thresholds markers so the re-injection block doesn't preempt
4. Ran the **unmodified** `alive-context-watch.sh` against simulated stdin

Hook output:

```json
{
  "hookSpecificOutput": {
    "hookEventName": "UserPromptSubmit",
    "additionalContext": "Another session just saved to alive-os. Changed: now.json tasks.json log.md. You should re-read _kernel/now.json, _kernel/tasks.json and _kernel/log.md before continuing -- your context may be stale. Ask the human if they want you to refresh."
  }
}
```

The injection fires correctly. **The hook was never broken — the only missing link was the walnut field never being populated.** Negative test also green: same setup with `walnut: null` correctly bails out without injecting.

---

## t003 — index regeneration triggers (`hooks/scripts/alive-post-write.sh`, `hooks/scripts/alive-session-new.sh`)

**Diagnosis.** `generate-index.py` was only triggered by the post-write hook chain `log.md → project.py → now.json → generate-index.py`. Any state change that doesn't route through a walnut save left `_index.yaml` stale until the next save — files dropped into `03_Inbox/` via Finder, parallel session writes, manual edits, agent captures.

**Fix — two narrow additions:**

1. **`alive-post-write.sh`:** added `*/03_Inbox/*` to the existing case statement that triggers `generate-index.py`. When the agent uses Write or Edit on a file under any `03_Inbox/`, the index regenerates (debounced via the existing `/tmp/alive-index-regen` marker, 5-minute window).

2. **`alive-session-new.sh`:** run `generate-index.py` synchronously just before reading `_index.yaml` for the SessionStart injection. **Measured at ~110ms on a 16-walnut world**, well under the 10s SessionStart hook timeout. Touches the debounce marker so subsequent post-write triggers within 5 minutes skip. This catches everything that happened between sessions — Finder drops, parallel saves, external edits — so the injected `<WORLD_INDEX>` is always fresh from byte one of every session.

**Verification (6 dummy tests, all green):**

- post-write inbox trigger: fed a fake Write to `03_Inbox/dummy-test.txt` → index mtime jumped from backdated 13:53 → 15:53, debounce marker created.
- **Negative test**: post-write to a non-inbox/non-now.json file (`berties/random-file.txt`) → no regen (proves the new glob doesn't accidentally match unrelated paths).
- **Regression test**: post-write to `now.json` still triggers regen (existing behavior unaffected).
- session-start sync regen: backdated `_index.yaml` to -3h, ran `alive-session-new.sh` → index mtime updated to NOW, output contains `<WORLD_INDEX>` block.
- `_index.yaml` integrity preserved after regen.

**Uncovered edge case (acceptable for v1).** Files dragged into `03_Inbox/` via Finder *during* an active session don't fire any Claude Code tool event, so neither trigger catches them. The world skill's t001 fix already does live `ls` for inbox detection so the dashboard view stays accurate; the only stale consumer in that window is the injected `<WORLD_INDEX>` snapshot, which gets refreshed on the next session start.

---

## Pattern observation

Three of the three bugs share a pattern: hooks and skills had the right intent but brittle implementation that silently failed.

- **t001:** relative path that depends on cwd
- **t002:** missing skill instruction → null field → consumers no-op
- **t003:** narrow trigger conditions that don't cover the full state-change surface area

The architectural insight (also recorded in `_kernel/insights.md` of the testing world): ALIVE projections (`_index.yaml`, `now.json`) assume save events fire frequently enough to keep derived state fresh. They don't. Any state change that bypasses the post-write trigger chain leaves projections stale indefinitely. This class of bug will keep biting other parts of the system until either the trigger graph widens to cover every state mutation, or projections become pull-based with freshness checks at the consumer side. This PR widens the trigger graph for the inbox case and the session-start case — worth a structural conversation about going further.

---

## Pre-existing edge case discovered (not in this PR, just flagging)

In `alive-context-watch.sh`, the CTX_PCT re-injection block (lines 33-148) exits at line 147 when a threshold fires, before reaching the external-change-detection block. This means the cross-session injection is preempted on the (at most 4) prompts per session where CTX_PCT crosses a 20%/40%/60%/80% threshold. Lastcheck marker doesn't advance on threshold-firing prompts (the early `exit 0` skips line 201's `date +%s > "$LASTCHECK"`), so the very next non-firing prompt catches up correctly. **Mostly benign — at worst a one-prompt delay, never a lost detection** — but worth noting in case anyone trips over it later. Could be cleaned up by emitting both `additionalContext` blocks in a single hook output instead of exiting early. Out of scope for this warmup PR.

---

## Follow-ups (intentionally not in this PR)

- **Capture-context archive behavior.** `capture-context/SKILL.md` doesn't reliably move source files out of `03_Inbox/` after routing them into a bundle's `raw/`. Designed and tested an archive-to-`03_Inbox/.archive/YYYY-MM/` patch in the same session, then rolled it back at the user's request — they're still discussing whether to keep originals as raw+references or pure-archive. Will reopen as a separate PR once that decision lands.
- **Walnut-claim coverage.** `create-walnut` and `bundle` skills should also claim the session in the squirrel YAML when they're the entry point to a walnut. Open question: should walnut-claim be hook-enforced (e.g. PostToolUse on Read of `*/key.md`) rather than skill-instructed? Skill instructions depend on the agent following them; hook enforcement is guaranteed.
- **`$WORLD_ROOT` shadow bug** in `world/SKILL.md` line 232 — the `python3 .alive/scripts/generate-index.py "$WORLD_ROOT"` invocation references a variable that's never set in the Bash tool's shell. Should follow the same `~/.config/alive/world-root` resolve pattern from t001. Tiny fix, didn't want to expand scope.
- **CTX_PCT preemption** — see above.

---

## Test plan

- [x] t001 verified before/after with `/tmp` cwd reproduction
- [x] t001 5 dummy test cases (real, empty, mixed-with-dotfiles, unrelated cwd, regression)
- [x] t002 verified end-to-end with real session YAML, real walnut, simulated parallel-session save
- [x] t002 negative test (walnut: null still bails — proves load fix is necessary)
- [x] t003 inbox trigger verified with fake post-write hook input
- [x] t003 negative test (non-inbox file doesn't trigger)
- [x] t003 regression test (now.json trigger still works)
- [x] t003 session-start regen verified with backdated index + fake SessionStart input
- [x] Windows dep audit clean (no fixes required — `stat`, `sed -i`, `md5sum`/`shasum` all have proper BSD fallbacks; no `jq`/`yq`/`gdate`/etc; no bash 4+ features; no hardcoded paths in hook code)
- [x] Cache-vs-clone parity verified (`diff -r` clean)
- [ ] **Live sanity check by maintainer:** open a fresh Claude Code session in a real world, run `/alive:world`, verify inbox count is correct; run `/alive:load-context {walnut}`, verify the session's squirrel YAML is updated to `walnut: {name}`. (This is the only thing I can't run from inside an existing session.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)