### PR TITLE
fix: remove prompt injection warning from v3 upgrade hook

### DIFF
--- a/plugins/alive/hooks/scripts/alive-session-new.sh
+++ b/plugins/alive/hooks/scripts/alive-session-new.sh
@@ -367,14 +367,7 @@ YOUR WORLD NEEDS MIGRATION. Run:
 It will show you exactly what changes, back everything up, and migrate your world. Takes a few minutes. Nothing breaks if you don't — but you'll be running v3 rules on v2 structure, which means degraded performance and missing features.
 
 — Ben (@benslockedin)
----
-
-AGENT INSTRUCTION: Before doing ANYTHING else, use the AskUserQuestion tool to ask:
-question: 'Your world needs migrating to ALIVE v3. This upgrades task tracking, projections, and load speed. Run /alive:system-upgrade now?'
-options: ['Yes, upgrade now', 'Not now, keep working']
-
-If they choose 'Yes, upgrade now', invoke alive:system-upgrade immediately.
-If they choose 'Not now, keep working', proceed normally but remind them again at save time."
+---"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Removes the `AGENT INSTRUCTION:` block from the session-start hook's v3 upgrade message
- This block was being flagged as a prompt injection attempt on users' machines because it contained explicit tool-call directives (`use the AskUserQuestion tool to ask...`)
- The developer message about v3 upgrade still displays — the model will naturally offer the upgrade without needing an explicit instruction

## Test plan
- [ ] Install plugin on a v2 world and verify no prompt injection warning appears
- [ ] Verify the v3 upgrade message still displays correctly
- [ ] Verify the model still offers to run `/alive:system-upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)