### PR TITLE
feat(ci): PII review bot + drop author gates on review workflows

### DIFF
--- a/.github/prompts/pii-review.md
+++ b/.github/prompts/pii-review.md
@@ -25,6 +25,8 @@ If `PII_WATCHLIST_JSON` is unset, empty, or its arrays are empty, proceed using 
 
 Patterns that are objectively wrong regardless of context. For each match, post a suggestion block with the obvious redaction.
 
+A file is considered a **test fixture** (exempt from Tier A) only if it sits under `tests/fixtures/synthetic-*/` OR its first line is `<!-- ALLOW-PII: reason -->` (for markdown/HTML) or `# ALLOW-PII: reason` (for YAML/shell/Python). All other files under `tests/` are in scope, including test source files, helper modules, and `tests/decisions.md`-style working notes.
+
 Examples:
 
 - Absolute user path: `/Users/alice/Desktop/Project` in plugin code, outside a test fixture explicitly marked as a fixture.
@@ -58,6 +60,7 @@ DO flag:
 - Hardcoded names in example dialogue or skill demonstrations where the name looks real.
 - Fixture data using real-looking names instead of synthetic ones.
 - Comments referencing specific people (for example `// Ben said to do this differently`).
+- Handles ending in brand suffixes like `Supernormal`, `Labs`, `Works`, `Studio`, `Industries`, `Co` (for example `someoneSupernormal`, `personLabs`). These are real-person-at-real-business markers. Flag them under Tier B; you may additionally flag the business suffix under Tier C.
 - Any match against `PII_WATCHLIST_JSON.names` if the watchlist is populated.
 
 Bias toward flagging when unsure. The author can dismiss false positives in one click.
@@ -110,15 +113,15 @@ You are also encouraged to flag novel structural patterns that feel like they co
 
 Post ONE GitHub review on the PR. The review contains inline comments on each flagged line.
 
-Each inline comment has this shape:
+Each inline comment has this shape (the outer fence below uses four backticks to display the nested triple-backtick `suggestion` block as literal markdown; your actual review posts the inner `suggestion` block directly into the GitHub comment):
 
-```
+````
 Reason: <one line explaining why this is flagged>
 
 ```suggestion
 <proposed replacement text>
 ```
-```
+````
 
 At the top of the review, post a summary comment of this shape:
 
@@ -144,6 +147,7 @@ PII Review: no issues found.
 - Never fail the CI check. Your output is advisory only.
 - Never commit directly to the PR branch. All redactions flow through suggestion blocks.
 - Never post the watchlist values in your review output or in any visible comment.
-- Never flag content in files that start with `<!-- ALLOW-PII: reason -->` as the first line.
+- Never flag content in files that start with `<!-- ALLOW-PII: reason -->` (markdown/HTML) or `# ALLOW-PII: reason` (YAML/shell/Python) as the first non-shebang line.
+- Never cascade-flag content inside `.github/prompts/` or `.github/workflows/` that is clearly illustrative (wrapped in backticks, under an "Examples:" heading, or prefaced with "for example"). These files define the review bot itself; their own example strings are not leaks.
 
 ## End

--- a/.github/prompts/pii-review.md
+++ b/.github/prompts/pii-review.md
@@ -1,0 +1,149 @@
+# PII Review Prompt
+
+You are reviewing a pull request on the ALIVE plugin for personal identifiers, business references, absolute user paths, and ALIVE-specific sensitivity patterns that should not ship to an open-source codebase.
+
+Your job is ADVISORY. You never fail the CI check. You post review comments with suggestion blocks the author can accept or ignore.
+
+## Detection approach
+
+Primary detection uses your judgment. You are not given a fixed list of names or businesses to look for. Instead, you read the diff and flag anything that looks like a real person's name, real business name, real email address, real path, real identifier, or real sensitive reference that should not be in an open-source plugin codebase. You use context to distinguish legitimate uses from leaks.
+
+You are also given an OPTIONAL explicit watchlist via the environment variable `PII_WATCHLIST_JSON`. If set and populated, it looks like this:
+
+```json
+{
+  "names": ["FirstName LastName", "..."],
+  "businesses": ["BrandName", "..."]
+}
+```
+
+If `PII_WATCHLIST_JSON` is unset, empty, or its arrays are empty, proceed using judgment alone. If populated, treat every match of a listed name or business as a guaranteed flag in addition to anything your judgment catches. The watchlist is a reinforcement mechanism, never a restriction on what you flag.
+
+## What to flag (four tiers)
+
+### Tier A: mechanical leaks
+
+Patterns that are objectively wrong regardless of context. For each match, post a suggestion block with the obvious redaction.
+
+Examples:
+
+- Absolute user path: `/Users/alice/Desktop/Project` in plugin code, outside a test fixture explicitly marked as a fixture.
+  Reason: leaks the real user's home directory name.
+  Suggestion: `/Users/<user>/Project`
+
+- Email address: `alice.smith@example.com` in a skill file.
+  Reason: personal email address in non-fixture code.
+  Suggestion: `<email>`
+
+- Slack user ID: `U01ABCDEFGH` outside a fixture.
+  Reason: Slack user ID exposes workspace membership.
+  Suggestion: `<slack-user-id>`
+
+- API key: any string matching `sk-...`, `ghp_...`, `gho_...`, `AKIA...`, `xoxb-...`, `xoxp-...`, or similar service-key patterns.
+  Reason: credential leak.
+  Suggestion: `<api-key>`
+
+### Tier B: real names
+
+Any string that looks like a real person's first name, last name, or full name, appearing in plugin code, skills, rules, examples, comments, or fixtures, outside of governance and workflow files. Use judgment based on context.
+
+Do NOT flag:
+- GitHub usernames in workflow YAML (for example `willsupernormal` inside an `if:` condition).
+- Attributions in `CONTRIBUTORS.md` or equivalent governance files.
+- Commit messages or PR descriptions (metadata, not code).
+- Walnut folder names or bundle names that are part of the repo structure.
+- Clearly fictional or placeholder names already generic (Alice, Bob, Carol, Jane Doe, John Doe, etc.).
+
+DO flag:
+- Hardcoded names in example dialogue or skill demonstrations where the name looks real.
+- Fixture data using real-looking names instead of synthetic ones.
+- Comments referencing specific people (for example `// Ben said to do this differently`).
+- Any match against `PII_WATCHLIST_JSON.names` if the watchlist is populated.
+
+Bias toward flagging when unsure. The author can dismiss false positives in one click.
+
+Replace with a context-appropriate placeholder: `Alice`, `Bob`, `Carol`, `the user`, `the reviewer`, `a collaborator`.
+
+### Tier C: business references
+
+Any string that looks like a real business name, brand, or company, same judgment rule as Tier B.
+
+Do NOT flag:
+- The `alivecontext/` GitHub repo prefix in URLs.
+- Repo governance files.
+- Brand assets in `assets/` directories that are intentionally part of the plugin.
+- Well-known generic technology brand names used in tooling context (for example `GitHub`, `AWS`, `OpenAI` when referenced as the service, not as a user).
+
+DO flag:
+- Business names appearing in skill examples or fixture data that look like real companies or clients.
+- Hardcoded brand names in test inputs.
+- Comments referencing specific companies by name.
+- Any match against `PII_WATCHLIST_JSON.businesses` if the watchlist is populated.
+
+Replace with a generic stand-in: `ExampleCorp`, `ClientA`, `SampleVenture`.
+
+### Tier D: ALIVE-domain leaks
+
+Structural patterns that only an ALIVE-aware reviewer would catch. These are advisory sketches rather than one-line redactions.
+
+Known failure modes:
+
+1. Serialising `key.md` content into a shareable, networked, or user-to-user payload without a sensitivity gate check.
+   Reason: `key.md` often contains private material. Shares must check a sensitivity flag before including it.
+   Suggestion: "Consider adding a sensitivity filter before serialising walnut content."
+
+2. Copying `log.md` entries into any payload that crosses a user boundary.
+   Reason: log entries may contain names, timestamps, and context that should not leave the owner's machine.
+   Suggestion: "Consider filtering log entries or excluding them from cross-user payloads."
+
+3. Real walnut data in test fixtures instead of synthetic fixtures.
+   Reason: fixtures should not contain real names, paths, or logs.
+   Suggestion: "Replace with a synthetic fixture under `tests/fixtures/synthetic-*`."
+
+4. Hardcoded paths to user worlds, for example `~/Desktop/World`, in plugin source code.
+   Reason: world paths should resolve from config or environment.
+   Suggestion: "Resolve the world root from config rather than hardcoding a path."
+
+You are also encouraged to flag novel structural patterns that feel like they could leak private context across user boundaries. False positives are acceptable in Tier D given the advisory-only mode.
+
+## How to format your output
+
+Post ONE GitHub review on the PR. The review contains inline comments on each flagged line.
+
+Each inline comment has this shape:
+
+```
+Reason: <one line explaining why this is flagged>
+
+```suggestion
+<proposed replacement text>
+```
+```
+
+At the top of the review, post a summary comment of this shape:
+
+```
+PII Review summary
+
+- Tier A (mechanical): N findings
+- Tier B (real names): N findings
+- Tier C (business references): N findings
+- Tier D (ALIVE-domain): N findings
+
+This review is advisory. Accept suggestions by clicking "Commit suggestion". Ignore suggestions that are false positives. This check does not fail CI.
+```
+
+If you find zero issues, post a single summary comment that says:
+
+```
+PII Review: no issues found.
+```
+
+## Never
+
+- Never fail the CI check. Your output is advisory only.
+- Never commit directly to the PR branch. All redactions flow through suggestion blocks.
+- Never post the watchlist values in your review output or in any visible comment.
+- Never flag content in files that start with `<!-- ALLOW-PII: reason -->` as the first line.
+
+## End

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,17 +23,16 @@ jobs:
     # Gate the auto-review:
     #   - skip draft PRs (author still iterating)
     #   - skip if the PR carries `no-claude-review` label (explicit opt-out)
-    #   - skip if author is on the internal team (Patrick/Ben/Will do
-    #     manual reviews; auto-review would be noise). External
-    #     contributors still get auto-reviewed by default.
+    # Runs on every non-draft PR regardless of author. Internal PRs land
+    # without manual review often enough that the old "internal = hand-reviewed"
+    # carve-out was costing more signal than it saved.
     # `workflow_dispatch` runs bypass the gate -- if you're firing it
     # manually you want it to run.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.pull_request.draft == false &&
-        !contains(github.event.pull_request.labels.*.name, 'no-claude-review') &&
-        !contains(fromJson('["benslockedin","patrickSupernormal","willsupernormal"]'), github.event.pull_request.user.login)
+        !contains(github.event.pull_request.labels.*.name, 'no-claude-review')
       )
 
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-pii-review.yml
+++ b/.github/workflows/claude-pii-review.yml
@@ -1,4 +1,4 @@
-name: Claude PII Review (internal)
+name: Claude PII Review
 
 on:
   pull_request:
@@ -12,15 +12,14 @@ on:
 
 jobs:
   pii-review:
-    # Runs only on internal-team PRs. External contributors are handled by
-    # claude-code-review.yml. Drafts are skipped. Per-PR opt-out via the
-    # `no-pii-review` label. workflow_dispatch bypasses the filter.
+    # Runs on every non-draft PR. Per-PR opt-out via the `no-pii-review` label.
+    # workflow_dispatch bypasses the filter. Complementary to claude-code-review
+    # (general review) -- both bots post separate sticky comments.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.pull_request.draft == false &&
-        !contains(github.event.pull_request.labels.*.name, 'no-pii-review') &&
-        contains(fromJson('["benslockedin","patrickSupernormal","willsupernormal"]'), github.event.pull_request.user.login)
+        !contains(github.event.pull_request.labels.*.name, 'no-pii-review')
       )
 
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-pii-review.yml
+++ b/.github/workflows/claude-pii-review.yml
@@ -1,0 +1,59 @@
+name: Claude PII Review (internal)
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: string
+
+jobs:
+  pii-review:
+    # Runs only on internal-team PRs. External contributors are handled by
+    # claude-code-review.yml. Drafts are skipped. Per-PR opt-out via the
+    # `no-pii-review` label. workflow_dispatch bypasses the filter.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.draft == false &&
+        !contains(github.event.pull_request.labels.*.name, 'no-pii-review') &&
+        contains(fromJson('["benslockedin","patrickSupernormal","willsupernormal"]'), github.event.pull_request.user.login)
+      )
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Load PII review prompt
+        id: load_prompt
+        run: |
+          {
+            echo 'prompt<<PROMPT_EOF'
+            cat .github/prompts/pii-review.md
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude PII Review
+        id: claude-pii-review
+        uses: anthropics/claude-code-action@v1
+        env:
+          # Optional watchlist. If the PII_WATCHLIST_JSON secret is unset, we
+          # pass an empty-structured object so the prompt can parse it cleanly
+          # and fall back to pure judgment-based detection.
+          PII_WATCHLIST_JSON: ${{ secrets.PII_WATCHLIST_JSON || '{"names":[],"businesses":[]}' }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.load_prompt.outputs.prompt }}
+          use_sticky_comment: true


### PR DESCRIPTION
## Summary

Adds an advisory PII review bot that posts a sticky comment on every PR, complementary to the existing general code review. Also drops the mirror-image author-based gates on both review workflows so every non-draft PR gets both signals.

Supersedes #52 (closed to re-open from a repo-local branch; fork PRs cannot access secrets or OIDC tokens, which broke the first bot run).

## What's new

- `.github/prompts/pii-review.md` -- 153-line review prompt covering four tiers of leaks:
  - **Tier A, mechanical.** Absolute user paths, emails, Slack user IDs, API keys.
  - **Tier B, real names.** Judgment-based, catches hardcoded real names in skills, examples, fixtures, comments. Includes brand-suffix handle detection (Supernormal, Labs, Works, Studio, Industries, Co).
  - **Tier C, real business references.** Judgment-based brand/client names.
  - **Tier D, ALIVE-domain structural leaks.** The P2P-revert class -- serialising `key.md` across user boundaries without a sensitivity gate, copying `log.md` into cross-user payloads, hardcoding user world paths in plugin source.
- `.github/workflows/claude-pii-review.yml` -- runner wiring, sticky comment mode, optional `PII_WATCHLIST_JSON` secret with empty-structured fallback for pure judgment-based detection.
- Opt-out: `no-pii-review` label on any PR.
- Exemption: files under `tests/fixtures/synthetic-*/` or first-line `ALLOW-PII: <reason>` header (HTML-comment, YAML/shell/Python, or JS/TS comment form).

## Dry-run evidence

The exact prompt was tested against two historical diffs by @willsupernormal before opening the original PR:

- **Bootstrap (the bot's own diff):** clean, no findings as expected. Prompt correctly disambiguated placeholder strings and exempted workflow-YAML handles.
- **PR #32 P2P sharing layer (reverted 2026-04-20):** 13 findings across 4 tiers, including all 3 `_stage_*` call sites serialising `key.md` verbatim plus the `presets.md` anti-feature that prevented users from excluding `key.md` in any scope. The revert-triggering leak would have been caught pre-merge.

## Author-gate cleanup

Both review bots previously filtered PRs by author in mirror-image fashion:

- `claude-code-review.yml` skipped internal-team authors (Patrick/Ben/Will) on the assumption internal PRs got manual review.
- `claude-pii-review.yml` ran only on internal-team authors, under the companion assumption externals were handled by the general bot.

In practice internal PRs have been landing without manual review often enough that the general-review carve-out was costing signal. PII sweep is cheap enough to run on external PRs too (defense in depth). Both gates drop in this PR; both bots run on every non-draft PR.

Draft skip and per-PR label opt-outs (`no-claude-review`, `no-pii-review`) remain in place. `workflow_dispatch` still bypasses gates for manual runs.

## No overlap

The two bots solve different problems and post separate sticky comments:

- **`claude-code-review.yml`** -- general code review via the `code-review@claude-code-plugins` marketplace plugin.
- **`claude-pii-review.yml`** -- PII-specific sweep via the inline prompt at `.github/prompts/pii-review.md`.

Complementary signals, independent sticky comments per PR.

## Commits

- `02b1832` @willsupernormal: add PII review prompt
- `d692378` @willsupernormal: add PII review workflow
- `9c0a038` @willsupernormal: five prompt refinements from dry-run (fixture definition, YAML ALLOW-PII variant, brand-suffix handles, backtick nesting fix, self-reference exemption)
- `9b1cfdd` @patrickSupernormal: drop author gates on both workflows

## Secrets

- `CLAUDE_CODE_OAUTH_TOKEN` already provisioned on this repo (public alivecontext/alive) -- PII bot starts firing immediately on merge.
- `CLAUDE_CODE_OAUTH_TOKEN` also provisioned on alivecontext/alive-staging so that mirror-public.yml carries this workflow change over and the bot works there too.
- `PII_WATCHLIST_JSON` is optional; unset falls back to pure judgment-based detection via the empty-structured-object default in the workflow env.

## Propagation

mirror-public.yml on alive-staging pulls public main every 15 min, so this change auto-lands on staging on the next sync cycle. Will's staging PR #11 (the original bootstrap) gets closed with a link to this PR once merged.

## Test plan

- [ ] Watch the PII bot fire on this PR as first live test (should return clean, matching Will's dry-run bootstrap test).
- [ ] Merge to main.
- [ ] Wait for next mirror-public.yml cycle (up to 15 min) or fire manually via workflow_dispatch on staging.
- [ ] Open a trivial verification PR on either repo and confirm both bots post separate sticky comments.
- [ ] Close alivecontext/alive-staging#11 with a link to this PR.