### PR TITLE
fix: wire inline-comment MCP server on both review bots

### DIFF
--- a/.github/prompts/pii-review.md
+++ b/.github/prompts/pii-review.md
@@ -111,9 +111,17 @@ You are also encouraged to flag novel structural patterns that feel like they co
 
 ## How to format your output
 
-Post ONE GitHub review on the PR. The review contains inline comments on each flagged line.
+Do NOT use `gh api`, `gh pr review`, `WebFetch`, or any other posting path. The only sanctioned tools for posting findings are the two below.
 
-Each inline comment has this shape (the outer fence below uses four backticks to display the nested triple-backtick `suggestion` block as literal markdown; your actual review posts the inner `suggestion` block directly into the GitHub comment):
+### Inline suggestions (one per finding)
+
+Call `mcp__github_inline_comment__create_inline_comment` once per finding, with:
+
+- `path`: the file path as it appears in the diff
+- `line`: the line number in the PR head (for multi-line spans, set `startLine` to the first line and `line` to the last)
+- `side`: `"RIGHT"` (the default) — comments attach to the PR head, not the base
+- `confirmed`: `true` — bypass the post-session probe-classifier and post the comment verbatim
+- `body`: the reason + suggestion in this shape (the outer fence below uses four backticks to display the nested triple-backtick `suggestion` block as literal markdown; your actual `body` contains the inner `suggestion` block directly):
 
 ````
 Reason: <one line explaining why this is flagged>
@@ -123,23 +131,25 @@ Reason: <one line explaining why this is flagged>
 ```
 ````
 
-At the top of the review, post a summary comment of this shape:
+### Summary comment (one per PR, at the end)
 
-```
-PII Review summary
+After all inline suggestions are posted, run ONE `gh pr comment` to post the summary:
+
+```bash
+gh pr comment <PR_NUMBER> --body "PII Review summary
 
 - Tier A (mechanical): N findings
 - Tier B (real names): N findings
 - Tier C (business references): N findings
 - Tier D (ALIVE-domain): N findings
 
-This review is advisory. Accept suggestions by clicking "Commit suggestion". Ignore suggestions that are false positives. This check does not fail CI.
+This review is advisory. Accept suggestions by clicking \"Commit suggestion\". Ignore suggestions that are false positives. This check does not fail CI."
 ```
 
-If you find zero issues, post a single summary comment that says:
+If you find zero issues across all tiers, skip the inline step entirely and post only:
 
-```
-PII Review: no issues found.
+```bash
+gh pr comment <PR_NUMBER> --body "PII Review: no issues found."
 ```
 
 ## Never

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,5 +60,15 @@ jobs:
           # Keep a single sticky comment on the PR instead of stacking a
           # new review per synchronize push.
           use_sticky_comment: true
+          # Boot both comment-posting MCP servers. Without these entries the
+          # action never writes to /tmp/inline-comments-buffer.jsonl and the
+          # post-step logs "No buffered inline comments" regardless of what
+          # the /code-review plugin did during the review. Same root cause
+          # and fix as claude-pii-review.yml — the action only installs the
+          # github_inline_comment + github_comment servers when allowedTools
+          # names them. Verified on alive-staging honeypot PR #15 for the
+          # PII prompt; same allowlist shape applied here for the plugin.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-pii-review.yml
+++ b/.github/workflows/claude-pii-review.yml
@@ -56,3 +56,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.load_prompt.outputs.prompt }}
           use_sticky_comment: true
+          # Inline-comment MCP server and the gh subcommands the prompt needs.
+          # Without the mcp__github_inline_comment__* entry the server is not
+          # booted, the buffer at /tmp/inline-comments-buffer.jsonl stays
+          # empty, and the post-step logs "No buffered inline comments"
+          # regardless of what Claude did during the review. Verified on
+          # alive-staging honeypot PR #15 run 24867482196 (8 inline
+          # suggestions + summary, all tiers fired).
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Wires up the MCP tools the Claude review bots need to post review output.

## Root cause

`anthropics/claude-code-action@v1` only installs its `github_inline_comment` and `github_comment` MCP servers when the workflow's `claude_args` names them in `--allowedTools`. Neither workflow passed `claude_args`, so the servers weren't booted and the action's comment buffer at `/tmp/inline-comments-buffer.jsonl` stayed empty — the post-step logs `No buffered inline comments`.

## Verification

Tested end-to-end on `alive-staging` PR #15 honeypot (run `24867482196`): 8 inline suggestions with well-formed ```suggestion``` blocks plus a summary comment with tier counts (3 Tier A, 2 Tier B, 1 Tier C, 2 Tier D) against 9 intentional triggers in a `.py` file.

## Changes

1. `.github/workflows/claude-pii-review.yml` — add `claude_args` with `mcp__github_inline_comment__create_inline_comment` + `gh pr comment/diff/view`.
2. `.github/workflows/claude-code-review.yml` — same plus `mcp__github_comment__update_claude_comment` for the sticky summary the `/code-review` plugin uses.
3. `.github/prompts/pii-review.md` — rewrite "How to format your output" to explicitly invoke the MCP tool by name with `confirmed: true`, and `gh pr comment` for the summary. Explicit negatives added: no `gh api`, no `gh pr review`, no `WebFetch`.

## Follow-ups (not in this PR)

- `workflow_dispatch.inputs.pr_number` is unwired on `claude-pii-review.yml` — cosmetic, separate PR.
- `alive-staging` has a transient `show_full_output: true` on the PII workflow from diagnosis PR #17. `mirror-public.yml` will overwrite it with this clean version within 15 minutes — no manual revert needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>