### PR TITLE
feat: promote-staging-to-public workflow (manual v1)

### DIFF
--- a/.github/workflows/promote-staging.yml
+++ b/.github/workflows/promote-staging.yml
@@ -1,0 +1,112 @@
+name: promote staging to public
+
+# Opens a PR on public `alivecontext/alive` containing commits that live
+# on `alivecontext/alive-staging:main` but not yet on public main.
+#
+# This is the reverse direction of mirror-public.yml. Together they form
+# the promote-to-release flow: work lands on staging, gets tested there
+# (CI, review bots, optional human review), and is then proposed for
+# public via this workflow.
+#
+# v1 is manual-trigger only; a cron may come later once the shape settles.
+# The workflow runs ON alive-staging (requires PROMOTE_TOKEN secret there
+# with repo + workflow scope on alivecontext/alive). This file is committed
+# to public alivecontext/alive as the source of truth; mirror-public.yml
+# copies it to alive-staging within 15 min, and the `if:` guard below
+# prevents a dispatch on public from opening a self-referential PR.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    # Only run when dispatched on alive-staging; no-op if dispatched on public.
+    if: github.repository == 'alivecontext/alive-staging'
+    steps:
+      - name: Checkout staging main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.PROMOTE_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "alive-staging-promote"
+          git config user.email "alive-staging-promote@users.noreply.github.com"
+
+      - name: Add public remote + fetch
+        env:
+          GH_TOKEN: ${{ secrets.PROMOTE_TOKEN }}
+        run: |
+          git remote add public "https://x-access-token:${GH_TOKEN}@github.com/alivecontext/alive.git"
+          git fetch public main
+
+      - name: Check divergence
+        id: diff
+        run: |
+          ahead=$(git rev-list public/main..HEAD --count)
+          behind=$(git rev-list HEAD..public/main --count)
+          echo "ahead=$ahead"   >> "$GITHUB_OUTPUT"
+          echo "behind=$behind" >> "$GITHUB_OUTPUT"
+          echo "Staging ahead: $ahead commits, behind public: $behind commits."
+
+      - name: Nothing to promote
+        if: steps.diff.outputs.ahead == '0'
+        run: echo "Staging is not ahead of public. Exiting cleanly."
+
+      - name: Prepare promotion branch on public
+        if: steps.diff.outputs.ahead != '0'
+        id: prep
+        env:
+          GH_TOKEN: ${{ secrets.PROMOTE_TOKEN }}
+        run: |
+          ts=$(date +%Y%m%d-%H%M)
+          branch="promote/staging-${ts}"
+
+          # Start from public main, merge staging main on top. This produces
+          # a single merge commit on public that carries all staging-unique
+          # commits with original authorship preserved.
+          git checkout -b "$branch" public/main
+          if ! git merge --no-ff main -m "promote: merge staging main $(git rev-parse --short main)"; then
+            echo "::error::Merge conflicts between staging and public. Staging has diverged non-trivially; resolve manually."
+            exit 1
+          fi
+          git push public "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR on public
+        if: steps.diff.outputs.ahead != '0'
+        env:
+          GH_TOKEN: ${{ secrets.PROMOTE_TOKEN }}
+        run: |
+          body=$(mktemp)
+          {
+            echo "Promoting **${{ steps.diff.outputs.ahead }}** staging commit(s) to public main."
+            echo ""
+            echo "## Commits"
+            echo ""
+            git log --reverse --pretty=format:'- \`%h\` %s (%an, %ad)' --date=short public/main..main
+            echo ""
+            echo ""
+            echo "## Review checklist"
+            echo ""
+            echo "- CI on this PR is green"
+            echo "- Review bot comments addressed (or explicitly dismissed)"
+            echo "- No workflow-file changes that require a separate self-test PR"
+            echo ""
+            echo "Merge with \`--merge\` (not \`--squash\`) to preserve author attribution."
+            echo ""
+            echo "---"
+            echo "*Automated by \`.github/workflows/promote-staging.yml\` on alive-staging.*"
+          } > "$body"
+          gh pr create \
+            --repo alivecontext/alive \
+            --base main \
+            --head "${{ steps.prep.outputs.branch }}" \
+            --title "promote: staging to public" \
+            --body-file "$body"


### PR DESCRIPTION
Adds the reverse-direction flow we've always intended: staging as a promotion branch that proposes to public.

## Shape

- Triggered by `workflow_dispatch` only (v1). Cron may follow once cadence settles.
- Runs on alive-staging (mirror-public.yml replicates this file there within 15 min). The `if:` guard makes a dispatch on public a clean no-op so the workflow doesn't try to self-reference.
- Opens a PR on public via a merge commit, preserving original author attribution across all staging commits.
- Fails loudly on merge conflicts rather than auto-committing a conflict-marker commit.

Together with `mirror-public.yml`:

```
public alivecontext/alive main
    │          ▲
    │          │  promote-staging.yml (manual dispatch → PR on public)
    │          │
    │  mirror-public.yml (every 15 min, auto-merge-or-sync-PR)
    ▼          │
staging alive-staging main
```

## One-time setup required after merge

Provision a `PROMOTE_TOKEN` secret on alivecontext/alive-staging:

1. Create a fine-grained PAT at github.com/settings/tokens?type=beta
   - Repository access: `alivecontext/alive`
   - Repository permissions: Contents (read + write), Pull requests (read + write), Workflows (read + write)
2. Store as repo secret `PROMOTE_TOKEN` on alive-staging.

Without the secret the workflow will fail immediately on checkout step — that's the intentional v1 failure shape, no side effects on public.

## First-exercise test plan

After PROMOTE_TOKEN is in place:
- Dispatch from alive-staging Actions tab
- Expected: PR opened on public with all currently-staging-ahead commits (at time of merge, that's whatever staging holds that public doesn't — likely small if you dispatch immediately after a sync PR closes)
- If PR opens cleanly and the diff looks right → close the test PR, real usage begins on next genuine promotion

## Follow-ups

- Cron schedule (v1.1) once cadence is understood
- Divergence / conflict auto-handling if merges get messy in practice
- Auto-labeling promotion PRs for dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>