### PR TITLE
fix: README install command — marketplace add before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 ---
 
 ```bash
+claude plugin marketplace add alivecontext/alive
 claude plugin install alive@alivecontext
 ```
 
@@ -180,6 +181,7 @@ EXIT ──→ Sign session. Final projection.
 ## Install
 
 ```bash
+claude plugin marketplace add alivecontext/alive
 claude plugin install alive@alivecontext
 ```
 


### PR DESCRIPTION
The copy-paste install command in the README is the one-step `claude plugin install alive@alivecontext`, which fails with **Plugin not found in marketplace** unless the marketplace was already added — exactly what #69 reported on June 18, where the reporter also confirmed the working two-step fix.

This updates both occurrences (hero + Install section) to:

```bash
claude plugin marketplace add alivecontext/alive
claude plugin install alive@alivecontext
```

Smallest possible diff; no other README changes. Closes #69 (comment to reporter to confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)